### PR TITLE
Docs: Update guide for deployment to Cloudflare

### DIFF
--- a/src/content/docs/en/guides/deploy/cloudflare.mdx
+++ b/src/content/docs/en/guides/deploy/cloudflare.mdx
@@ -32,7 +32,6 @@ To get started, you will need:
     - **Framework preset**: `Astro`
     - **Build command:** `npm run build`
     - **Build output directory:** `dist`
-    - **Environment variables (advanced)**: By default, Cloudflare Pages uses Node.js 12.18.0, but Astro [requires a higher version](/en/install/auto/#prerequisites). Add an environment variable with a **Variable name** of `NODE_VERSION` and a **Value** of `v16.13.0` or higher to tell Cloudflare to use a compatible Node version. Alternatively, add a `.nvmrc` file to your project to specify a Node version.
 
 7. Click the **Save and Deploy** button.
 


### PR DESCRIPTION
- Cloudflare Pages now uses Node.js 18.16.0 by default
- Reference: https://blog.cloudflare.com/moderizing-cloudflare-pages-builds-toolbox/

<!-- Thank you for opening a PR! We really appreciate you taking the time to help out 🙌 -->

#### What kind of changes does this PR include?

- New or updated content

#### Description

Previously, the guide recommended specifying a newer Node.js version in a .nvmrc file due to Cloudflare's use of Node.js 12.18.0. However, Cloudflare Pages has since updated to Node.js 18.16.0 by default.

I've removed the section in the guide that advised specifying a newer Node.js version. This aligns with Cloudflare's latest default settings and ensures the guide remains current.

I've removed the section in the guide that advised specifying a newer Node.js version. This aligns with Cloudflare's latest default settings and ensures the guide remains current.

For reference, check out the Cloudflare Pages blog post: [Modernizing the Cloudflare Pages Builds Toolbox](https://blog.cloudflare.com/moderizing-cloudflare-pages-builds-toolbox/)
